### PR TITLE
ci: auto-fix dependabot PRs by regenerating third-party/BUCK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       sweep:
-        description: 'Run the full crate sweep'
+        description: 'Run the full crate sweep (false = normal PR jobs)'
         type: boolean
         default: true
 
@@ -23,7 +23,10 @@ env:
 jobs:
   linux:
     name: linux ${{ matrix.arch }}
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    # workflow_dispatch with sweep=false runs the normal PR jobs: the
+    # dependabot helper uses it to re-run CI after pushing a fix (pushes made
+    # with GITHUB_TOKEN don't retrigger pull_request workflows).
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.sweep)
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +65,7 @@ jobs:
 
   macos:
     name: macos aarch64
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.sweep)
     runs-on: macos-latest
     permissions:
       contents: read

--- a/.github/workflows/dependabot-helper.yml
+++ b/.github/workflows/dependabot-helper.yml
@@ -1,0 +1,61 @@
+# Dependabot bumps third-party/Cargo.{toml,lock} but can't run `reindeer
+# buckify`, so its PRs always fail the buckify-check. This workflow
+# regenerates third-party/BUCK on dependabot's PR branch, pushes the fix,
+# and re-dispatches CI (a GITHUB_TOKEN push doesn't retrigger pull_request
+# workflows; workflow_dispatch is exempt from that recursion guard).
+name: Dependabot helper
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['third-party/**']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  regenerate-buck:
+    # Same-repo dependabot branches only — never run PR code from forks or
+    # other authors with a write token.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.head_ref, 'dependabot/') &&
+      github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # push the regenerated BUCK to the PR branch
+      actions: write   # re-dispatch ci.yml after the push
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Install earthly
+        uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+        with:
+          version: v0.8.15
+
+      - name: Regenerate third-party/BUCK
+        run: earthly +buckify
+
+      - name: Commit, push, re-dispatch CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          git add third-party/BUCK
+          if git diff --staged --quiet; then
+            echo "third-party/BUCK already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "ci: regenerate third-party/BUCK"
+          git push origin "HEAD:$HEAD_REF"
+          gh workflow run ci.yml --ref "$HEAD_REF" -f sweep=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ header from 38 fixups that were authored here, not copied from the
 facebook/buck2 or ocamlrep shims (template copy-paste artifact). Added
 .github/dependabot.yml (cargo now lives in /third-party) with a 7-day
 cooldown. build-all.sh now detects mid-build DICE cancellation instead of
-reporting unbuilt targets as failures.
+reporting unbuilt targets as failures. Added dependabot-helper workflow:
+dependabot can't run reindeer, so its third-party bumps always failed
+buckify-check; the helper regenerates third-party/BUCK (new earthly
++buckify target), pushes the fix to the PR branch, and re-dispatches CI
+(workflow_dispatch with sweep=false now runs the normal PR jobs, since
+GITHUB_TOKEN pushes don't retrigger pull_request workflows).
 
 2026-06-11
 Expected-failure lists cut to one entry (aws-lc-sys on linux; macOS empty).

--- a/Earthfile
+++ b/Earthfile
@@ -39,6 +39,14 @@ buckify-check:
         if [ $rc -ne 0 ] || [ -n "$output" ]; then echo "buckify (exit $rc):"; echo "$output"; exit 1; fi; \
         diff -u /tmp/BUCK.committed third-party/BUCK || { echo "committed third-party/BUCK is stale — re-run reindeer buckify"; exit 1; }
 
+# Regenerate third-party/BUCK and write it back to the host. Used by the
+# dependabot-helper workflow to fix bot PRs that bump third-party deps
+# without re-running reindeer; also handy locally.
+buckify:
+    FROM +src
+    RUN reindeer buckify
+    SAVE ARTIFACT third-party/BUCK AS LOCAL third-party/BUCK
+
 # Prove the repo works as a buck2 cell named `fixups` (README contract).
 test-cell:
     FROM +src


### PR DESCRIPTION
dependabot PRs always make the CI red. let's fix this.