### PR TITLE
ci: harden dependabot helper + manual dispatch

### DIFF
--- a/.github/workflows/dependabot-helper.yml
+++ b/.github/workflows/dependabot-helper.yml
@@ -9,9 +9,15 @@ on:
   pull_request:
     branches: [main]
     paths: ['third-party/**']
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Dependabot PR number to regenerate'
+        type: number
+        required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: true
 
 permissions: {}
@@ -19,11 +25,17 @@ permissions: {}
 jobs:
   regenerate-buck:
     # Same-repo dependabot branches only — never run PR code from forks or
-    # other authors with a write token.
+    # other authors with a write token. Gate on the PR author, not the event
+    # actor: "Update branch" / manual pushes by maintainers fire synchronize
+    # with the human as actor, and the helper should still heal those.
+    # workflow_dispatch needs write access to fire; the resolve step below
+    # re-validates the branch.
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.head_ref, 'dependabot/') &&
-      github.actor == 'dependabot[bot]'
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.head_ref, 'dependabot/') &&
+        github.event.pull_request.user.login == 'dependabot[bot]'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write  # push the regenerated BUCK to the PR branch
@@ -31,15 +43,47 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
+      # On dispatch, resolve the PR number to its branch and re-apply the
+      # pull_request gate (same-repo, dependabot/* prefix) before any
+      # checkout happens.
+      - name: Resolve PR branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_REF: ${{ github.head_ref }}
+          PR: ${{ inputs.pr }}
+        run: |
+          if [ -n "$EVENT_REF" ]; then
+            ref="$EVENT_REF"
+          else
+            ref=$(gh pr view "$PR" -R "$GITHUB_REPOSITORY" \
+                  --json headRefName,isCrossRepository \
+                  --jq 'if .isCrossRepository then error("cross-repo PR") else .headRefName end')
+          fi
+          case "$ref" in
+            dependabot/*) ;;
+            *) echo "::error::not a dependabot branch: $ref"; exit 1 ;;
+          esac
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: Checkout PR branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ steps.pr.outputs.ref }}
 
       - name: Install earthly
         uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: v0.8.15
+
+      # Dependabot branches fork from an older main and may predate the
+      # +buckify target (or carry a stale recipe). Always build with main's
+      # Earthfile — it's also the trusted copy, not branch content. Worktree
+      # only (not staged), so the commit below only carries third-party/BUCK.
+      - name: Use Earthfile from main
+        run: |
+          git fetch --depth=1 origin main
+          git show FETCH_HEAD:Earthfile > Earthfile
 
       - name: Regenerate third-party/BUCK
         run: earthly +buckify
@@ -47,7 +91,7 @@ jobs:
       - name: Commit, push, re-dispatch CI
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REF: ${{ steps.pr.outputs.ref }}
         run: |
           git add third-party/BUCK
           if git diff --staged --quiet; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ dependabot can't run reindeer, so its third-party bumps always failed
 buckify-check; the helper regenerates third-party/BUCK (new earthly
 +buckify target), pushes the fix to the PR branch, and re-dispatches CI
 (workflow_dispatch with sweep=false now runs the normal PR jobs, since
-GITHUB_TOKEN pushes don't retrigger pull_request workflows).
+GITHUB_TOKEN pushes don't retrigger pull_request workflows). Helper
+hardened after first contact: gate on PR author rather than event actor
+(so maintainer "Update branch" still heals), and build with main's
+Earthfile (dependabot branches fork from an older main that may predate
+the +buckify target), plus a workflow_dispatch trigger to force a run on
+any PR number.
 
 2026-06-11
 Expected-failure lists cut to one entry (aws-lc-sys on linux; macOS empty).


### PR DESCRIPTION
First contact with real dependabot PRs (#39) surfaced three gaps in the helper:

- **Stale-branch Earthfile**: dependabot branches fork from an older main that may predate the `+buckify` target (`target buckify not found`). The helper now builds with main's Earthfile — fetched into the worktree only, so the pushed commit still carries just `third-party/BUCK`. Also means the build recipe always comes from trusted main rather than branch content.
- **Actor vs author gate**: maintainer actions ("Update branch", manual pushes) fire `synchronize` with the human as actor, so the `github.actor == 'dependabot[bot]'` gate skipped runs that should heal. Gate now checks the PR author; same-repo + `dependabot/*` prefix checks unchanged.
- **No manual override**: added `workflow_dispatch` with a `pr` number input to force a run on any dependabot PR (`gh workflow run dependabot-helper.yml -f pr=N`). A resolve step re-applies the trust checks (same-repo, `dependabot/*`) before checkout; branch names reach shells only via env.