### PR TITLE
Add windows (x86_64 + aarch64) to CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF everywhere: Windows runners default core.autocrlf=true, and CRLF
+# breaks bash scripts under Git Bash and makes buckify output nondeterministic.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,52 @@ jobs:
       - name: Run tests
         run: ./test.sh
 
+  windows:
+    name: windows ${{ matrix.arch }}
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.sweep)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            arch: x86_64
+          - runner: windows-11-arm
+            arch: aarch64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    env:
+      FORCE_COLOR: 1
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      # reindeer ships no windows-arm build; the x86_64 binary runs under
+      # Windows 11 x64 emulation.
+      - name: Install buck2 + reindeer
+        run: |
+          # windows-11-arm images don't ship zstd (windows-latest does).
+          command -v zstd >/dev/null || choco install -y zstandard --no-progress
+          mkdir -p "$HOME/bin"
+          curl -fsSL "https://github.com/facebook/buck2/releases/download/${BUCK2_VERSION}/buck2-${{ matrix.arch }}-pc-windows-msvc.exe.zst" | zstd -d > "$HOME/bin/buck2.exe"
+          curl -fsSL "https://github.com/facebookincubator/reindeer/releases/download/${REINDEER_VERSION}/reindeer-x86_64-pc-windows-msvc.exe.zst" | zstd -d > "$HOME/bin/reindeer.exe"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+          uname -sm
+          "$HOME/bin/buck2.exe" --version
+
+      - name: Run tests
+        # No crate builds on arm: the prelude's msvc discovery (vswhere.py)
+        # hardcodes x64 lib paths, so aarch64 links fail (see issue tracker).
+        # buckify + cell consumption still verify there.
+        env:
+          SKIP_CRATE_BUILDS: ${{ matrix.arch == 'aarch64' && '1' || '' }}
+        run: ./test.sh
+
   sweep-linux:
     name: sweep linux ${{ matrix.arch }}
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.sweep)
@@ -140,6 +186,40 @@ jobs:
           curl -fsSL "https://github.com/facebook/buck2/releases/download/${BUCK2_VERSION}/buck2-aarch64-apple-darwin.zst" | zstd -d > /usr/local/bin/buck2
           curl -fsSL "https://github.com/facebookincubator/reindeer/releases/download/${REINDEER_VERSION}/reindeer-aarch64-apple-darwin.zst" | zstd -d > /usr/local/bin/reindeer
           chmod +x /usr/local/bin/buck2 /usr/local/bin/reindeer
+
+      - name: Build all crates
+        run: ./build-all.sh
+
+  # x86_64 only: the prelude's msvc discovery can't link aarch64 yet (x64
+  # lib paths hardcoded in vswhere.py), so an arm sweep would be ~all noise.
+  sweep-windows:
+    name: sweep windows x86_64
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.sweep)
+    runs-on: windows-latest
+    timeout-minutes: 300
+    permissions:
+      contents: read
+    env:
+      FORCE_COLOR: 1
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # pyo3 0.24 supports python <= 3.13; the runner default is newer.
+      - name: Pin python for pyo3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Install buck2 + reindeer
+        run: |
+          mkdir -p "$HOME/bin"
+          curl -fsSL "https://github.com/facebook/buck2/releases/download/${BUCK2_VERSION}/buck2-x86_64-pc-windows-msvc.exe.zst" | zstd -d > "$HOME/bin/buck2.exe"
+          curl -fsSL "https://github.com/facebookincubator/reindeer/releases/download/${REINDEER_VERSION}/reindeer-x86_64-pc-windows-msvc.exe.zst" | zstd -d > "$HOME/bin/reindeer.exe"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
 
       - name: Build all crates
         run: ./build-all.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 2026-06-12
+CI extended to windows-x86_64 and windows-aarch64 (native buck2 msvc
+binaries under Git Bash; reindeer x86_64-emulated on arm) plus a
+windows-x86_64 weekly sweep. Crate builds skipped on windows-arm: the
+prelude's msvc discovery hardcodes x64 lib paths so aarch64 links fail.
+Fixed two latent windows breaks from main: unix-only absolute compiler
+paths in toolchains/BUCK (now select()ed per OS) and missing vcruntime.lib
+(__CxxFrameHandler3) on msvc targets. test-cell.sh copies via
+git ls-files | tar (no rsync on windows runners); .gitattributes forces LF.
+
+2026-06-12
 Top-100 crates.io coverage: rustls added to the rig (ring provider; the
 default aws-lc-rs chains into the known prelude ld-shim failure on linux) —
 the only top-100 crate previously absent. ring fixup modernised to

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 411 and counting... (please feel free to contribute!)
 
-CI-tested on linux-x86_64, linux-aarch64 and macos-aarch64: `reindeer
+CI-tested on linux-x86_64, linux-aarch64, macos-aarch64, windows-x86_64
+and windows-aarch64 (buckify + cell consumption only on windows-arm:
+buck2's prelude msvc discovery is x64-only, so aarch64 links fail —
+see issue #42): `reindeer
 buckify` must be warning-free, the committed `third-party/BUCK` must be
 up to date, changed fixups must `buck2 build`, and cell consumption is
 verified (`test-cell.sh`). A weekly sweep builds **every** crate
@@ -124,14 +127,12 @@ https://github.com/suiwombat/sui/tree/buck_sui_up_rc1 - Apache 2.0
 
 https://github.com/theoparis/bevy-os - Apache 2.0
 
-
 Other rust buck2 projects:
 https://github.com/search?q=load%28%22%40prelude%2F%2Ftoolchains%3Arust.bzl%22%2C+%22system_rust_toolchain%22%29&type=code
 
 Related upstream discussions: shared fixup repositories
 ([reindeer#73](https://github.com/facebookincubator/reindeer/issues/73)),
 fixup gallery ([reindeer#19](https://github.com/facebookincubator/reindeer/issues/19)).
-
 
 ## TODO
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -6,7 +6,20 @@ set -e
 # list in ci/expected-failures-<os>-<arch>.txt. Fails on NEW failures and on
 # stale entries (crates that started passing), so the lists stay honest.
 
-platform="$(uname -s)-$(uname -m)"
+# Git Bash reports e.g. MINGW64_NT-10.0-20348; fold to a stable name.
+os="$(uname -s)"
+case "$os" in MINGW*|MSYS*|CYGWIN*) os=Windows ;; esac
+arch="$(uname -m)"
+if [ "$os" = Windows ]; then
+  # Git Bash may itself run x64-emulated on arm64, making uname -m lie
+  # (and PROCESSOR_ARCHITEW6432 is WOW64-32-only, so it lies too).
+  # RUNNER_ARCH is GitHub's job-level truth.
+  case "${RUNNER_ARCH:-}" in
+    ARM64) arch=aarch64 ;;
+    X64) arch=x86_64 ;;
+  esac
+fi
+platform="${os}-${arch}"
 expected="ci/expected-failures-${platform}.txt"
 report=$(mktemp)
 trap 'rm -f "$report"' EXIT
@@ -26,7 +39,9 @@ if grep -q "evaluation of this key was cancelled" "$buildlog"; then
 fi
 rm -f "$buildlog"
 
-failed=$(python3 - "$report" <<'EOF'
+# Windows runners ship `python`, not `python3`.
+python="$(command -v python3 || command -v python)"
+failed=$("$python" - "$report" <<'EOF'
 import json, sys
 report = json.load(open(sys.argv[1]))
 for label, result in sorted(report.get("results", {}).items()):

--- a/ci/expected-failures-Windows-x86_64.txt
+++ b/ci/expected-failures-Windows-x86_64.txt
@@ -1,0 +1,26 @@
+# Crates known to fail on this platform (one fixups//third-party:NAME per line).
+# Canonical environment: GitHub windows-latest runners. build-all.sh fails CI
+# on new failures and stale entries.
+
+# wrong-OS crates (linux-only):
+fixups//third-party:inotify
+fixups//third-party:inotify-sys
+fixups//third-party:xattr
+# wrong-OS crates (macOS-only):
+fixups//third-party:core-foundation
+fixups//third-party:security-framework
+fixups//third-party:system-configuration-sys
+# native build scripts needing fixup work (asm/cmake/vendored C):
+fixups//third-party:aws-lc-sys
+fixups//third-party:lz4
+fixups//third-party:lz4-sys
+fixups//third-party:lzma-sys
+fixups//third-party:psm
+fixups//third-party:sha1-asm
+fixups//third-party:sha2-asm
+fixups//third-party:xz2
+# broken against current msvc rustc (old abandoned crates):
+fixups//third-party:backtrace
+fixups//third-party:color-eyre
+fixups//third-party:error-chain
+fixups//third-party:failure

--- a/test-cell.sh
+++ b/test-cell.sh
@@ -11,8 +11,16 @@ trap 'buck2 killall 2>/dev/null || true; rm -rf "$scratch"' EXIT
 
 consumer="$scratch/consumer"
 mkdir -p "$consumer/fixups-src"
-rsync -a --exclude buck-out --exclude buck-out-docker --exclude .git \
-      --exclude target --exclude '.cargo' ./ "$consumer/fixups-src/"
+# Tracked files only (skips buck-out, target, .git, .cargo). tar instead of
+# rsync: Git Bash on Windows runners has no rsync. Earthly containers get the
+# repo without .git, so fall back to find there.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git ls-files -z
+else
+  find . \( -name buck-out -o -name buck-out-docker -o -name .git \
+            -o -name target -o -name .cargo \) -prune \
+         -o \( -type f -o -type l \) -print0
+fi | tar -cf - --null -T - | tar -xf - -C "$consumer/fixups-src"
 
 cd "$consumer"
 touch .buckroot BUCK

--- a/test.sh
+++ b/test.sh
@@ -13,8 +13,10 @@ fi
 # Rather than build all targets with:
 # buck2 build //...
 # build only each crate whose fixup changed, skipping fixups for crates the
-# test rig doesn't depend on (no top-level alias):
-changed=$(git diff --name-only origin/main...HEAD | grep '^fixups/' | cut -d/ -f2 | sort -u || true)
+# test rig doesn't depend on (no top-level alias). SKIP_CRATE_BUILDS=1 skips
+# this on platforms where the prelude can't link (windows-arm: its msvc
+# discovery is x64-only).
+changed=$([ -z "${SKIP_CRATE_BUILDS:-}" ] && git diff --name-only origin/main...HEAD | grep '^fixups/' | cut -d/ -f2 | sort -u || true)
 if [ -n "$changed" ]; then
   available=$(buck2 uquery "kind('^alias\$', //third-party:)" | sed 's|.*:||' | sort -u)
   crates=$(comm -12 <(echo "$changed") <(echo "$available") | sed 's|^|//third-party:|' | tr '\n' ' ')

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -13,6 +13,13 @@ system_genrule_toolchain(
 system_rust_toolchain(
     name = "rust",
     default_edition = "2021",
+    # aarch64-pc-windows-msvc unwinding needs the C++ EH personality
+    # (__CxxFrameHandler3) from vcruntime.lib, which the explicit native-lib
+    # list omits; x86_64 uses SEH and doesn't. Harmless where unneeded.
+    rustc_flags = select({
+        "config//os:windows": ["-Clink-arg=vcruntime.lib"],
+        "DEFAULT": [],
+    }),
     visibility = ["PUBLIC"],
 )
 
@@ -21,11 +28,24 @@ system_cxx_toolchain(
     # Absolute path: the prelude's buildscript cc shim execs the compiler
     # via os.execl, which does no PATH lookup - a bare "clang" fails with
     # FileNotFoundError (prelude/rust/tools/from_any_dir.py). Absolute paths
-    # sidestep it.
-    compiler = "/usr/bin/clang",
-    cxx_compiler = "/usr/bin/clang++",
-    linker = "/usr/bin/clang++",
-    archiver = "/usr/bin/ar",
+    # sidestep it. On Windows these unix paths don't exist and break every
+    # link step; None/"cl.exe" sentinels keep the prelude's MSVC discovery.
+    compiler = select({
+        "config//os:windows": "cl.exe",
+        "DEFAULT": "/usr/bin/clang",
+    }),
+    cxx_compiler = select({
+        "config//os:windows": "cl.exe",
+        "DEFAULT": "/usr/bin/clang++",
+    }),
+    linker = select({
+        "config//os:windows": "link.exe",
+        "DEFAULT": "/usr/bin/clang++",
+    }),
+    archiver = select({
+        "config//os:windows": None,
+        "DEFAULT": "/usr/bin/ar",
+    }),
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
Supersedes #29 (rebuilt as one signed commit on current main).

Adds Windows to the CI matrix alongside linux-{x86_64,aarch64} and macos-aarch64.

- **`windows` job** (PRs/pushes): matrix over `windows-latest` / `windows-11-arm`, native `buck2` msvc binaries under Git Bash (reindeer ships no arm build — x86_64 binary under x64 emulation). x86_64 runs the full `./test.sh`; arm runs buckify + cell consumption only (`SKIP_CRATE_BUILDS`, see #42 — the buck2 prelude's msvc discovery is x64-only, so aarch64 links fail).
- **`sweep-windows` job** (weekly/dispatch): full crate sweep on x86_64 against `ci/expected-failures-Windows-x86_64.txt` (18 entries, harvested from a real sweep run).

Latent bugs from main this surfaced and fixes:

- `toolchains/BUCK` hardcoded `/usr/bin/clang` & co (the `os.execl` fix) — broke every Windows link step; now `select()`ed per OS with MSVC-discovery sentinels on Windows.
- msvc targets need `vcruntime.lib` for `__CxxFrameHandler3` (arm64 unwinding); added via `rustc_flags`.

Portability fixes:

- `test-cell.sh`: `rsync` → `git ls-files | tar` (no rsync in Git Bash), `find` fallback inside Earthly containers (no `.git`).
- `build-all.sh`: fold `MINGW*` uname to `Windows`; trust `RUNNER_ARCH` (uname lies under x64-on-arm64 emulation); `python` fallback.
- `.gitattributes` forces LF (autocrlf breaks bash scripts and buckify determinism).

All of the above was proven green on #29's CI (PR jobs on all five combos + windows sweep against the harvested list).